### PR TITLE
Fixed input crashing after 51 character

### DIFF
--- a/src/low_level/interrupts.rs
+++ b/src/low_level/interrupts.rs
@@ -1,10 +1,16 @@
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 
-use crate::{hlt_loop, low_level::gdt, print, println};
+use crate::{
+    hlt_loop,
+    low_level::{
+        gdt,
+        user_interface::{handle_keypress, handle_raw_keypress},
+    },
+    println,
+};
 use pic8259::ChainedPics;
 use spin;
-
 pub const PIC_1_OFFSET: u8 = 32;
 pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
 
@@ -76,7 +82,6 @@ extern "x86-interrupt" fn keyboard_interrupt_handler(_stack_frame: InterruptStac
             }
         }
     }
-
     unsafe {
         PICS.lock()
             .notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
@@ -110,21 +115,5 @@ impl InterruptIndex {
 
     fn as_usize(self) -> usize {
         usize::from(self.as_u8())
-    }
-}
-//Backspace is implemented twice because even though it has a rawkey, its registered as Unicode.
-//If in some case it would be a raw key, it would cause bugs
-
-fn handle_keypress(key: char) {
-    match key {
-        '\u{8}' => super::vga_buffer::backspace(),
-        _ => print!("{}", key),
-    }
-}
-use pc_keyboard::KeyCode;
-fn handle_raw_keypress(key: KeyCode) {
-    match key {
-        KeyCode::Backspace => super::vga_buffer::backspace(),
-        _ => print!("{:?}", key),
     }
 }

--- a/src/low_level/mod.rs
+++ b/src/low_level/mod.rs
@@ -2,4 +2,5 @@ pub mod allocator;
 pub mod gdt;
 pub mod interrupts;
 pub mod memory;
+pub mod user_interface;
 pub mod vga_buffer;

--- a/src/low_level/user_interface.rs
+++ b/src/low_level/user_interface.rs
@@ -1,0 +1,21 @@
+//here goes proccessing the input from the user
+//Backspace is implemented twice because even though it has a rawkey, its registered as Unicode.
+//If in some case it would be a raw key, it would cause bugs
+use crate::{low_level::vga_buffer::backspace, print};
+
+pub fn handle_keypress(key: char) {
+    match key {
+        '\u{8}' => backspace(),
+        _ => print!("{}", key),
+    }
+}
+use pc_keyboard::KeyCode;
+pub fn handle_raw_keypress(key: KeyCode) {
+    match key {
+        KeyCode::Backspace => backspace(),
+        KeyCode::LShift => {}
+        KeyCode::RShift => {}
+        KeyCode::CapsLock => {}
+        _ => print!("{:?}", key),
+    }
+}

--- a/src/low_level/vga_buffer.rs
+++ b/src/low_level/vga_buffer.rs
@@ -24,7 +24,6 @@ pub enum Color {
     Yellow = 0x0E,
     White = 0x0F,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 struct ColorCode(u8);
@@ -44,7 +43,9 @@ struct Char {
 
 const BUFFER_HEIGHT: usize = 25;
 const BUFFER_WIDTH: usize = 80;
-
+const ACTUAL_BUFFER_WIDTH: usize = 50;
+//Added because input stopped working after user tried to enter the 51 character.
+//Probably qemu issue, maybe there is a way, but this is the temporary fix
 #[repr(transparent)]
 struct Buffer {
     chars: [[Char; BUFFER_WIDTH]; BUFFER_HEIGHT],
@@ -58,7 +59,7 @@ pub struct Writer {
 
 impl Writer {
     pub fn write_byte(&mut self, byte: u8) {
-        if byte == b'\n' || self.column_position >= BUFFER_WIDTH {
+        if byte == b'\n' || self.column_position >= ACTUAL_BUFFER_WIDTH {
             self.next_line();
             return;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
     clear_screen!(Color::Black);
 
     print_with_colors!(
-        MessageToVga::new(Color::Yellow, Color::Black, "Welcome to the "),
+        MessageToVga::new(Color::White, Color::Black, "Welcome to the "),
         MessageToVga::new(Color::LightBlue, Color::Black, "Popcorn Kernel!\n")
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 #![no_std] // don't link the Rust standard library
 #![no_main] // disable all Rust-level entry points
-
 use core::panic::PanicInfo;
 extern crate alloc;
-
 /// This function is called on panic.
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
@@ -23,11 +21,9 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
     clear_screen!(Color::Black);
 
     print_with_colors!(
-        MessageToVga::new(Color::White, Color::Black, "Welcome to the "),
+        MessageToVga::new(Color::Yellow, Color::Black, "Welcome to the "),
         MessageToVga::new(Color::LightBlue, Color::Black, "Popcorn Kernel!\n")
     );
-
-    set_color!(Color::White, Color::Black);
 
     init(boot_info);
 


### PR DESCRIPTION
The input stopped working after 51 character is typed, so  a newline is automatically entered. Also did a minor tweak that shit and capslock is not printed since capital letters work without being implemented